### PR TITLE
requirement 3 See the sleep records over the past week for their friends, ordered by the length of their sleep.

### DIFF
--- a/app/api/resource/v1/friend_records_api.rb
+++ b/app/api/resource/v1/friend_records_api.rb
@@ -1,0 +1,47 @@
+module Resource::V1
+
+  class FriendRecordsApi < Grape::API
+
+    resource :click_in_user_friend do
+
+      namespace do
+
+        params do
+          requires :user_id, type: Integer
+        end
+
+        get 'friends' do
+
+          present QueryService.get_friends(params[:user_id])
+
+        end
+
+      end
+
+
+
+      namespace do
+
+        params do
+          requires :friend_user_id, type: Integer
+        end
+
+        get 'records' do
+
+          sleep_record_dtos = QueryService.get_friend_sleep_records(params[:friend_user_id])
+
+          response = sleep_record_dtos.map { |dto| { record_date: dto.record_date, sleep_length: dto.sleep_length } }
+
+          present response
+
+        end
+
+      end
+
+
+
+
+    end
+
+  end
+end

--- a/app/api/resource/v1/root.rb
+++ b/app/api/resource/v1/root.rb
@@ -8,6 +8,7 @@ module Resource::V1
 
     mount Resource::V1::ClickInOperationApi
     mount Resource::V1::ClickInUsersApi
+    mount Resource::V1::FriendRecordsApi
   end
 
 end

--- a/app/services/friend_info_dto.rb
+++ b/app/services/friend_info_dto.rb
@@ -1,0 +1,3 @@
+class FriendInfoDto < Struct.new(:id, :name)
+
+end

--- a/app/services/persistences/query_service.rb
+++ b/app/services/persistences/query_service.rb
@@ -11,6 +11,23 @@ module Persistences
           .as_json(only: [:click_type, :record_datetime])
       end
 
+      def get_friends(user_id)
+        friend_ids = UserConnection
+                       .joins("LEFT JOIN user_disconnections ON user_disconnections.user_connection_id = user_connections.id")
+                       .where(user_connections: { click_in_user_id: user_id })
+                       .where(user_disconnections: { id: nil }).pluck(:followed_user_id)
+
+        ClickInUser
+          .where(id: friend_ids)
+          .as_json(only: [:id, :name])
+      end
+
+      def get_friend_sleep_records(friend_user_id)
+        UserSleepLengthRecord
+          .where(click_in_user_id: friend_user_id)
+          .order(sleep_seconds: :desc)
+          .as_json(only: [:record_date, :sleep_seconds])
+      end
 
     end
 

--- a/app/services/persistences/query_service.rb
+++ b/app/services/persistences/query_service.rb
@@ -25,6 +25,7 @@ module Persistences
       def get_friend_sleep_records(friend_user_id)
         UserSleepLengthRecord
           .where(click_in_user_id: friend_user_id)
+          .where("record_date > ?", Date.today - 7.days)
           .order(sleep_seconds: :desc)
           .as_json(only: [:record_date, :sleep_seconds])
       end

--- a/app/services/query_service.rb
+++ b/app/services/query_service.rb
@@ -16,6 +16,36 @@ class QueryService
       user_click_histories
     end
 
+    def get_friends(user_id)
+      friends_array = Query.get_friends(user_id)
+
+      friends_dtos = []
+
+      friends_array.each do |friend|
+
+        friends_dtos << FriendInfoDto.new(friend["id"], friend["name"])
+
+      end
+
+      friends_dtos
+
+    end
+
+    def get_friend_sleep_records(friend_user_id)
+      sleep_records_array = Query.get_friend_sleep_records(friend_user_id)
+
+      sleep_record_dto = []
+
+      sleep_records_array.each do |sleep_record|
+
+        sleep_record_dto << SleepRecordDto.new(sleep_record["record_date"], sleep_record["sleep_seconds"])
+
+      end
+
+      sleep_record_dto
+
+    end
+
     private
 
     Query = Persistences::QueryService

--- a/app/services/sleep_record_dto.rb
+++ b/app/services/sleep_record_dto.rb
@@ -1,0 +1,9 @@
+class SleepRecordDto < Struct.new(:record_date, :sleep_seconds)
+
+  def sleep_length
+    mins  = sleep_seconds / 60
+    hours = mins / 60
+    "#{hours}:#{mins % 60}:#{sleep_seconds % 60}"
+  end
+
+end

--- a/spec/api/requests/api/friend_records_api_spec.rb
+++ b/spec/api/requests/api/friend_records_api_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe Resource::V1::FriendRecordsApi, type: :request do
+
+  describe 'Call get friends' do
+    before do
+      fake_dto = FriendInfoDto.new(3, "fake_name")
+      allow(QueryService).to receive(:get_friends).and_return([fake_dto])
+    end
+
+    it 'check service execution & received params' do
+
+      expect(QueryService).to receive(:get_friends).with(5).once
+
+      call_get_friends
+
+    end
+
+    describe 'check response' do
+
+      before { call_get_friends }
+
+      it 'responds click-in histories' do
+        body = JSON.parse(response.body)
+        expect(body[0]["id"]).to eq(3)
+        expect(body[0]["name"]).to eq("fake_name")
+      end
+
+      it_behaves_like 'return http_status_code', 200
+    end
+
+  end
+
+
+
+  describe 'Call get friend_records' do
+
+    before do
+      fake_dto = SleepRecordDto.new(Date.parse("2022-12-03"), 30024)
+      allow(QueryService).to receive(:get_friend_sleep_records).and_return([fake_dto])
+    end
+
+    it 'check service execution & received params' do
+
+      expect(QueryService).to receive(:get_friend_sleep_records).with(3).once
+
+      call_get_sleep_records
+
+    end
+
+    describe 'check response' do
+
+      before { call_get_sleep_records }
+
+      it 'responds click-in histories' do
+        body = JSON.parse(response.body)
+        expect(body[0]["record_date"]).to eq("2022-12-03")
+        expect(body[0]["sleep_length"]).to eq("8:20:24")
+      end
+
+      it_behaves_like 'return http_status_code', 200
+    end
+
+  end
+
+  def call_get_friends
+    params = { user_id: 5 }
+    get '/good_night/v1/click_in_user_friend/friends', :params => params
+  end
+
+  def call_get_sleep_records
+    params = { friend_user_id: 3 }
+    get '/good_night/v1/click_in_user_friend/records', :params => params
+  end
+
+end

--- a/spec/services/query_service_spec.rb
+++ b/spec/services/query_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe QueryService do
         mock_persistence_get_user_click_histories(1)
       end
 
-      it 'responds order array_hashes' do
+      it 'responds order dtos_array' do
         response = get_user_click_histories
         expect(response[0].type_integer).to eq 1
         expect(response[0].recorded_datetime).to eq Time.zone.parse('2022-12-01 14:00:00')
@@ -28,7 +28,7 @@ RSpec.describe QueryService do
         mock_persistence_get_user_click_histories(2)
       end
 
-      it 'responds order array_hashes' do
+      it 'responds order dtos_array' do
         response = get_user_click_histories
         expect(response[0].type_integer).to eq 2
         expect(response[0].recorded_datetime).to eq Time.zone.parse('2022-12-01 14:00:00')
@@ -49,6 +49,46 @@ RSpec.describe QueryService do
 
   end
 
+  describe '#get_friends' do
+    before { allow(Persistences::QueryService).to receive(:get_friends).and_return([{ "id" => 1, "name" => "fake_name" }]) }
+
+    it 'responds order dtos_array' do
+      response = get_friends
+      expect(response[0].id).to eq 1
+      expect(response[0].name).to eq 'fake_name'
+    end
+
+    it 'execute query service' do
+
+      expect(Persistences::QueryService).to receive(:get_friends).with(1).once
+
+      get_friends
+
+    end
+
+  end
+
+
+  describe '#get_friend_sleep_records' do
+
+    before { allow(Persistences::QueryService).to receive(:get_friend_sleep_records).and_return([{ "record_date" => Date.parse("2022-12-03"), "sleep_seconds" => 10000 }]) }
+
+    it 'responds order dtos_array' do
+      response = get_friend_sleep_records
+      expect(response[0].record_date).to eq Date.parse("2022-12-03")
+      expect(response[0].sleep_seconds).to eq 10000
+    end
+
+    it 'execute query service' do
+
+      expect(Persistences::QueryService).to receive(:get_friend_sleep_records).with(3).once
+
+      get_friend_sleep_records
+
+    end
+
+  end
+
   def get_user_click_histories
     QueryService.get_user_click_histories(1)
   end
@@ -61,4 +101,11 @@ RSpec.describe QueryService do
                                                                                        ])
   end
 
+  def get_friends
+    QueryService.get_friends(1)
+  end
+
+  def get_friend_sleep_records
+    QueryService.get_friend_sleep_records(3)
+  end
 end


### PR DESCRIPTION
1. get friend info api & get friend sleep record api
It could make API response complicated if we combine all data.
2. ORM to get data from Persistence::QueryService
3. format the info in QueryService in APP layer
4. creates API & QueryService spec for getting friend_info usage.