### PR TITLE
invalid context for API.

### DIFF
--- a/app/api/resource/v1/click_in_operation_api.rb
+++ b/app/api/resource/v1/click_in_operation_api.rb
@@ -6,7 +6,7 @@ module Resource::V1
 
       params do
         requires :user_id, type: Integer
-        requires :click_type, type: String, desc: 'wake up or sleep'
+        requires :click_type, type: String, values: ["wake_up", "go_to_sleep"]
       end
 
       post '/' do

--- a/spec/api/requests/api/click_in_operation_api_spec.rb
+++ b/spec/api/requests/api/click_in_operation_api_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Resource::V1::ClickInOperationApi, type: :request do
 
-  # todo: write the expectation for invalid request (4XX, 5XX)
   describe 'click_in API' do
     before do
       allow(CommandService).to receive(:save_click_time).and_return(true)
@@ -70,7 +69,6 @@ RSpec.describe Resource::V1::ClickInOperationApi, type: :request do
       end
 
       describe 'check response' do
-
         before { call_api }
 
         it 'responds click-in histories' do
@@ -85,7 +83,25 @@ RSpec.describe Resource::V1::ClickInOperationApi, type: :request do
       end
 
     end
+  end
 
+  describe 'check abnormal pattern' do
+
+    context 'failure response with wrong user_id' do
+
+      before { post '/good_night/v1/click_in/', :params => { user_id: "wrong_type", click_type: "wake_up" } }
+
+      it_behaves_like 'return http_status_code', 400
+      it_behaves_like 'return error_message', "user_id is invalid"
+    end
+
+    context 'failure response with wrong click_type' do
+
+      before { post '/good_night/v1/click_in/', :params => { user_id: 1, click_type: 1 } }
+
+      it_behaves_like 'return http_status_code', 400
+      it_behaves_like 'return error_message', "click_type does not have a valid value"
+    end
 
   end
 

--- a/spec/api/requests/api/click_in_users_api_spec.rb
+++ b/spec/api/requests/api/click_in_users_api_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe Resource::V1::ClickInUsersApi, type: :request do
 
   end
 
+  describe 'check abnormal pattern for follow API' do
+
+    context 'failure response with wrong user_id' do
+
+      before { post '/good_night/v1/click_in_user/follow', :params => { user_id: "wrong_type", follow_user_id: 1 } }
+
+      it_behaves_like 'return http_status_code', 400
+      it_behaves_like 'return error_message', "user_id is invalid"
+    end
+
+    context 'failure response with wrong follow_user_id' do
+
+      before { post '/good_night/v1/click_in_user/follow', :params => { user_id: 1, follow_user_id: "wrong_type" } }
+
+      it_behaves_like 'return http_status_code', 400
+      it_behaves_like 'return error_message', "follow_user_id is invalid"
+    end
+
+  end
+
 
   describe 'call unfollow API' do
     before { allow(CommandService).to receive(:unfollow_user).and_return(true) }
@@ -44,6 +64,15 @@ RSpec.describe Resource::V1::ClickInUsersApi, type: :request do
 
       it_behaves_like 'return http_status_code', 201
     end
+
+  end
+
+  describe 'check abnormal pattern for unfollow API' do
+
+    before { post '/good_night/v1/click_in_user/unfollow', :params => { connection_id: "wrong_type" } }
+
+    it_behaves_like 'return http_status_code', 400
+    it_behaves_like 'return error_message', "connection_id is invalid"
 
   end
 

--- a/spec/api/requests/api/friend_records_api_spec.rb
+++ b/spec/api/requests/api/friend_records_api_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe Resource::V1::FriendRecordsApi, type: :request do
 
   end
 
+  describe 'check abnormal pattern for get friends API' do
+
+    before { get '/good_night/v1/click_in_user_friend/friends', :params => { user_id: "wrong_type" } }
+
+    it_behaves_like 'return http_status_code', 400
+    it_behaves_like 'return error_message', "user_id is invalid"
+
+  end
+
+
 
 
   describe 'Call get friend_records' do
@@ -60,6 +70,15 @@ RSpec.describe Resource::V1::FriendRecordsApi, type: :request do
 
       it_behaves_like 'return http_status_code', 200
     end
+
+  end
+
+  describe 'check abnormal pattern for get friend_records API' do
+
+    before { get '/good_night/v1/click_in_user_friend/records', :params => { friend_user_id: "wrong_type" } }
+
+    it_behaves_like 'return http_status_code', 400
+    it_behaves_like 'return error_message', "friend_user_id is invalid"
 
   end
 

--- a/spec/support/response_shared_examples.rb
+++ b/spec/support/response_shared_examples.rb
@@ -4,3 +4,10 @@ shared_examples 'return http_status_code' do |status_code|
     expect(response.status).to eq(status_code)
   end
 end
+
+# error message check
+shared_examples 'return error_message' do |error_message|
+  it "return #{error_message}" do
+    expect(JSON.parse(response.body)["error"]).to eq(error_message)
+  end
+end


### PR DESCRIPTION
There are lots of different invalid context, but it contains the spec in the gem.

So, I did not write all contexts for the invalid one.

Normally, the invalid contexts should be in spec only if the validation logic contains in API in my opinion.